### PR TITLE
feat: added the SLD calculator component as an MCP tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,13 @@ dependencies = [
 	"fastmcp>=3.0.0b1",
     "sans-fitter>=0.0.3",
     "kaleido>=1.2.0",
+    "periodictable>=1.7.0",
 ]
 
 [project.optional-dependencies]
 dev = [
 	"ruff>=0.14.10",
+	"pytest>=8.0",
 ]
 
 [project.scripts]

--- a/src/sans_pilot/main.py
+++ b/src/sans_pilot/main.py
@@ -19,6 +19,7 @@ from sans_pilot.files import (
   get_user_id_from_request,
   resolve_uploaded_path,
 )
+from sans_pilot.sld import calculate_neutron_sld
 
 mcp = FastMCP(
   "sans-pilot",
@@ -59,7 +60,8 @@ def describe_possibilities() -> str:
     "get-polydispersity-options (get PD distribution types and defaults), "
     "list-analyses (see available analysis types), "
     "list-uploaded-files (find data files), "
-    "run-analysis (execute an analysis and get fit results + plot)."
+    "run-analysis (execute an analysis and get fit results + plot), "
+    "calculate-sld (compute neutron SLD for a molecular formula and density)."
   )
 
 
@@ -271,6 +273,23 @@ async def run_analysis(
   analysis_result = await asyncio.to_thread(execute_analysis, name, parameters)
 
   return [analysis_result["fit"], Image(path=analysis_result["artifacts"]["plot"])]
+
+
+@mcp.tool(
+  name="calculate-sld",
+  description=(
+    "Calculate the Neutron Scattering Length Density (SLD) for a given "
+    "molecular formula and mass density. SLD values are essential for "
+    "SANS experiment planning — they determine contrast between sample "
+    "components and solvent. Uses the same algorithm as SasView's SLD calculator."
+  ),
+)
+def calculate_sld(
+  molecular_formula: str,
+  mass_density: float | None = None,
+  neutron_wavelength: float = 6.0,
+) -> dict:
+  return calculate_neutron_sld(molecular_formula, mass_density, neutron_wavelength)
 
 
 def main() -> None:

--- a/src/sans_pilot/sld.py
+++ b/src/sans_pilot/sld.py
@@ -1,0 +1,66 @@
+"""Neutron SLD calculation, ported from SasView's SldPanel."""
+
+from __future__ import annotations
+
+from periodictable.nsf import neutron_scattering
+
+_SCALE = 1e-6
+
+
+def calculate_neutron_sld(
+  molecular_formula: str,
+  mass_density: float | None = None,
+  neutron_wavelength: float = 6.0,
+) -> dict:
+  """Calculate the Neutron Scattering Length Density for a compound.
+
+  Args:
+      molecular_formula: Chemical formula (e.g. ``"H2O"``, ``"D2O"``).
+      mass_density: Mass density in g/cm³.  Required for simple formulas;
+          may be omitted when all component densities are embedded in the
+          formula via ``@density`` notation.
+      neutron_wavelength: Neutron wavelength in Ångströms (default 6.0).
+
+  Returns:
+      Dictionary with SLD results and unit metadata.
+  """
+  if not molecular_formula or not molecular_formula.strip():
+    raise ValueError("molecular_formula is required")
+  if neutron_wavelength <= 0:
+    raise ValueError("neutron_wavelength must be positive")
+  if mass_density is not None and mass_density <= 0:
+    raise ValueError("mass_density must be positive")
+
+  scattering_kwargs: dict = {
+    "compound": molecular_formula,
+    "wavelength": neutron_wavelength,
+  }
+  if mass_density is not None:
+    scattering_kwargs["density"] = mass_density
+
+  try:
+    (neutron_sld_real, neutron_sld_imag, _), \
+      (_, _neutron_abs_xs, _neutron_inc_xs), \
+      _neutron_length = neutron_scattering(**scattering_kwargs)
+  except KeyError as exc:
+    raise ValueError(
+      f"Unknown element or invalid formula: {molecular_formula}"
+    ) from exc
+  except Exception as exc:
+    # periodictable raises ValueError or pyparsing.exceptions.ParseException
+    raise ValueError(
+      f"Could not parse molecular formula '{molecular_formula}': {exc}"
+    ) from exc
+
+  return {
+    "molecular_formula": molecular_formula,
+    "mass_density": mass_density,
+    "neutron_wavelength": neutron_wavelength,
+    "neutron_sld_real": _SCALE * neutron_sld_real,
+    "neutron_sld_imag": _SCALE * abs(neutron_sld_imag),
+    "units": {
+      "neutron_sld": "Å⁻²",
+      "wavelength": "Å",
+      "density": "g/cm³",
+    },
+  }

--- a/src/sans_pilot/sld.py
+++ b/src/sans_pilot/sld.py
@@ -39,9 +39,11 @@ def calculate_neutron_sld(
     scattering_kwargs["density"] = mass_density
 
   try:
-    (neutron_sld_real, neutron_sld_imag, _), \
-      (_, _neutron_abs_xs, _neutron_inc_xs), \
-      _neutron_length = neutron_scattering(**scattering_kwargs)
+    (
+      (neutron_sld_real, neutron_sld_imag, _),
+      (_, _neutron_abs_xs, _neutron_inc_xs),
+      _neutron_length,
+    ) = neutron_scattering(**scattering_kwargs)
   except KeyError as exc:
     raise ValueError(
       f"Unknown element or invalid formula: {molecular_formula}"

--- a/test/test_sld.py
+++ b/test/test_sld.py
@@ -1,0 +1,145 @@
+"""Tests for the SLD calculation module."""
+
+from __future__ import annotations
+
+import pytest
+
+from sans_pilot.sld import calculate_neutron_sld
+
+
+# ---------------------------------------------------------------------------
+# Happy-path calculations (values cross-checked against SasView)
+# ---------------------------------------------------------------------------
+
+class TestWater:
+  def test_sld_real(self):
+    result = calculate_neutron_sld("H2O", mass_density=1.0, neutron_wavelength=6.0)
+    assert result["neutron_sld_real"] == pytest.approx(-5.6e-7, abs=1e-8)
+
+  def test_sld_imag_positive(self):
+    result = calculate_neutron_sld("H2O", mass_density=1.0, neutron_wavelength=6.0)
+    assert result["neutron_sld_imag"] > 0
+
+
+class TestHeavyWater:
+  def test_sld_real(self):
+    result = calculate_neutron_sld("D2O", mass_density=1.107, neutron_wavelength=6.0)
+    assert result["neutron_sld_real"] == pytest.approx(6.33e-6, abs=1e-7)
+
+
+class TestSiliconDioxide:
+  def test_sld_real(self):
+    result = calculate_neutron_sld("SiO2", mass_density=2.2, neutron_wavelength=6.0)
+    assert result["neutron_sld_real"] == pytest.approx(3.47e-6, abs=1e-7)
+
+
+class TestCustomWavelength:
+  def test_custom_wavelength_returns_valid_result(self):
+    # periodictable SLD values are wavelength-independent; wavelength only
+    # affects cross-sections (not returned by this tool).  Verify the tool
+    # accepts a non-default wavelength and produces consistent SLD values.
+    result = calculate_neutron_sld("H2O", mass_density=1.0, neutron_wavelength=1.8)
+    assert result["neutron_wavelength"] == 1.8
+    assert result["neutron_sld_real"] == pytest.approx(-5.6e-7, abs=1e-8)
+    assert result["neutron_sld_imag"] > 0
+
+
+class TestEmbeddedDensityMixture:
+  def test_no_external_density_required(self):
+    result = calculate_neutron_sld(
+      "50%vol H2O@1.0 // 50%vol D2O@1.107",
+      neutron_wavelength=6.0,
+    )
+    # Should return a result between pure H2O and pure D2O
+    assert result["neutron_sld_real"] > -5.6e-7
+    assert result["neutron_sld_real"] < 6.33e-6
+    assert result["mass_density"] is None
+
+
+# ---------------------------------------------------------------------------
+# Output shape
+# ---------------------------------------------------------------------------
+
+class TestOutputShape:
+  def test_keys(self):
+    result = calculate_neutron_sld("H2O", mass_density=1.0)
+    expected_keys = {
+      "molecular_formula",
+      "mass_density",
+      "neutron_wavelength",
+      "neutron_sld_real",
+      "neutron_sld_imag",
+      "units",
+    }
+    assert set(result.keys()) == expected_keys
+
+  def test_units(self):
+    result = calculate_neutron_sld("H2O", mass_density=1.0)
+    assert result["units"]["neutron_sld"] == "Å⁻²"
+    assert result["units"]["wavelength"] == "Å"
+    assert result["units"]["density"] == "g/cm³"
+
+  def test_echoes_inputs(self):
+    result = calculate_neutron_sld("SiO2", mass_density=2.2, neutron_wavelength=1.8)
+    assert result["molecular_formula"] == "SiO2"
+    assert result["mass_density"] == 2.2
+    assert result["neutron_wavelength"] == 1.8
+
+
+# ---------------------------------------------------------------------------
+# Validation / error paths
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+  def test_empty_formula_raises(self):
+    with pytest.raises(ValueError, match="molecular_formula is required"):
+      calculate_neutron_sld("", mass_density=1.0)
+
+  def test_whitespace_formula_raises(self):
+    with pytest.raises(ValueError, match="molecular_formula is required"):
+      calculate_neutron_sld("   ", mass_density=1.0)
+
+  def test_invalid_formula_raises(self):
+    with pytest.raises(ValueError):
+      calculate_neutron_sld("Zq3", mass_density=1.0)
+
+  def test_negative_density_raises(self):
+    with pytest.raises(ValueError, match="mass_density must be positive"):
+      calculate_neutron_sld("H2O", mass_density=-1.0)
+
+  def test_zero_wavelength_raises(self):
+    with pytest.raises(ValueError, match="neutron_wavelength must be positive"):
+      calculate_neutron_sld("H2O", mass_density=1.0, neutron_wavelength=0.0)
+
+  def test_negative_wavelength_raises(self):
+    with pytest.raises(ValueError, match="neutron_wavelength must be positive"):
+      calculate_neutron_sld("H2O", mass_density=1.0, neutron_wavelength=-1.0)
+
+
+# ---------------------------------------------------------------------------
+# MCP tool-level integration test
+# ---------------------------------------------------------------------------
+
+class TestMCPToolRegistration:
+  def test_calculate_sld_tool_exists(self):
+    """Verify the tool is registered on the MCP server."""
+    import asyncio
+
+    from sans_pilot.main import mcp
+
+    tools = asyncio.run(mcp.list_tools())
+    tool_names = [t.name for t in tools]
+    assert "calculate-sld" in tool_names
+
+  def test_invalid_input_returns_mcp_error(self):
+    """Calling the tool with an invalid formula should raise a ToolError
+    so the MCP protocol can return a structured error to the client."""
+    import asyncio
+
+    from fastmcp.exceptions import ToolError
+    from sans_pilot.main import mcp
+
+    with pytest.raises(ToolError, match="Could not parse"):
+      asyncio.run(
+        mcp.call_tool("calculate-sld", {"molecular_formula": "Zq3", "mass_density": 1.0})
+      )

--- a/test/test_sld.py
+++ b/test/test_sld.py
@@ -6,10 +6,10 @@ import pytest
 
 from sans_pilot.sld import calculate_neutron_sld
 
-
 # ---------------------------------------------------------------------------
 # Happy-path calculations (values cross-checked against SasView)
 # ---------------------------------------------------------------------------
+
 
 class TestWater:
   def test_sld_real(self):
@@ -60,6 +60,7 @@ class TestEmbeddedDensityMixture:
 # Output shape
 # ---------------------------------------------------------------------------
 
+
 class TestOutputShape:
   def test_keys(self):
     result = calculate_neutron_sld("H2O", mass_density=1.0)
@@ -89,6 +90,7 @@ class TestOutputShape:
 # ---------------------------------------------------------------------------
 # Validation / error paths
 # ---------------------------------------------------------------------------
+
 
 class TestValidation:
   def test_empty_formula_raises(self):
@@ -120,6 +122,7 @@ class TestValidation:
 # MCP tool-level integration test
 # ---------------------------------------------------------------------------
 
+
 class TestMCPToolRegistration:
   def test_calculate_sld_tool_exists(self):
     """Verify the tool is registered on the MCP server."""
@@ -137,9 +140,12 @@ class TestMCPToolRegistration:
     import asyncio
 
     from fastmcp.exceptions import ToolError
+
     from sans_pilot.main import mcp
 
     with pytest.raises(ToolError, match="Could not parse"):
       asyncio.run(
-        mcp.call_tool("calculate-sld", {"molecular_formula": "Zq3", "mass_density": 1.0})
+        mcp.call_tool(
+          "calculate-sld", {"molecular_formula": "Zq3", "mass_density": 1.0}
+        )
       )


### PR DESCRIPTION
This adds a new tool for calculating the neutron scattering length density (SLD) of chemical compounds, making these calculations available as a built-in feature of the MCP server. The implementation is based on SasView's SLD calculator.

**New SLD calculation feature:**

* Added a new `calculate_neutron_sld` function in `src/sans_pilot/sld.py` that computes neutron SLD for a given molecular formula and density, with input validation and error handling.
* Registered a new MCP tool, `calculate-sld`, in `src/sans_pilot/main.py` for users to access SLD calculations via the API.
* Updated the API description in `describe_possibilities` to include the new `calculate-sld` tool.
* Updated `pyproject.toml` to include `periodictable` as a required dependency and `pytest` as a dev dependency.